### PR TITLE
feat: add catalog and show details

### DIFF
--- a/mini-netflix/app/(tabs)/index.tsx
+++ b/mini-netflix/app/(tabs)/index.tsx
@@ -1,75 +1,67 @@
 import { Image } from 'expo-image';
-import { Platform, StyleSheet } from 'react-native';
+import { FlatList, Pressable, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
 
-import { HelloWave } from '@/components/HelloWave';
-import ParallaxScrollView from '@/components/ParallaxScrollView';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
+import { catalog } from '@/data/catalog';
 
 export default function HomeScreen() {
+  const router = useRouter();
+
   return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
-      headerImage={
-        <Image
-          source={require('@/assets/images/partial-react-logo.png')}
-          style={styles.reactLogo}
-        />
-      }>
-      <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Welcome!</ThemedText>
-        <HelloWave />
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 1: Try it</ThemedText>
-        <ThemedText>
-          Edit <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> to see changes.
-          Press{' '}
-          <ThemedText type="defaultSemiBold">
-            {Platform.select({
-              ios: 'cmd + d',
-              android: 'cmd + m',
-              web: 'F12',
-            })}
-          </ThemedText>{' '}
-          to open developer tools.
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 2: Explore</ThemedText>
-        <ThemedText>
-          {`Tap the Explore tab to learn more about what's included in this starter app.`}
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
-        <ThemedText>
-          {`When you're ready, run `}
-          <ThemedText type="defaultSemiBold">npm run reset-project</ThemedText> to get a fresh{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> directory. This will move the current{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
-          <ThemedText type="defaultSemiBold">app-example</ThemedText>.
-        </ThemedText>
-      </ThemedView>
-    </ParallaxScrollView>
+    <FlatList
+      data={catalog}
+      keyExtractor={(item) => item.id}
+      renderItem={({ item }) => (
+        <ThemedView style={styles.category}>
+          <ThemedText type="subtitle" style={styles.categoryTitle}>
+            {item.title}
+          </ThemedText>
+          <FlatList
+            data={item.shows}
+            keyExtractor={(show) => show.id}
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            renderItem={({ item: show }) => (
+              <Pressable
+                onPress={() =>
+                  router.push({ pathname: '/show/[id]', params: { id: show.id } })
+                }
+                style={styles.posterContainer}
+              >
+                <Image source={{ uri: show.poster }} style={styles.poster} />
+                <ThemedText numberOfLines={1} style={styles.posterTitle}>
+                  {show.title}
+                </ThemedText>
+              </Pressable>
+            )}
+          />
+        </ThemedView>
+      )}
+    />
   );
 }
 
 const styles = StyleSheet.create({
-  titleContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
+  category: {
+    marginBottom: 24,
   },
-  stepContainer: {
-    gap: 8,
+  categoryTitle: {
+    marginHorizontal: 8,
     marginBottom: 8,
   },
-  reactLogo: {
-    height: 178,
-    width: 290,
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
+  posterContainer: {
+    marginHorizontal: 8,
+    width: 120,
+  },
+  poster: {
+    width: 120,
+    height: 180,
+    borderRadius: 8,
+    marginBottom: 4,
+  },
+  posterTitle: {
+    textAlign: 'center',
   },
 });

--- a/mini-netflix/app/_layout.tsx
+++ b/mini-netflix/app/_layout.tsx
@@ -21,6 +21,7 @@ export default function RootLayout() {
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="show/[id]" options={{ title: 'Show' }} />
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />

--- a/mini-netflix/app/show/[id].tsx
+++ b/mini-netflix/app/show/[id].tsx
@@ -1,0 +1,63 @@
+import { Image } from 'expo-image';
+import { ScrollView, StyleSheet } from 'react-native';
+import { Stack, useLocalSearchParams } from 'expo-router';
+
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { findShowById } from '@/data/catalog';
+
+export default function ShowDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const show = findShowById(Array.isArray(id) ? id[0] : id);
+
+  if (!show) {
+    return (
+      <ThemedView style={styles.center}>
+        <ThemedText>No show found.</ThemedText>
+      </ThemedView>
+    );
+  }
+
+  return (
+    <ScrollView>
+      <Stack.Screen options={{ title: show.title }} />
+      <Image source={{ uri: show.poster }} style={styles.poster} />
+      <ThemedView style={styles.content}>
+        <ThemedText type="title">{show.title}</ThemedText>
+        <ThemedText style={styles.synopsis}>{show.synopsis}</ThemedText>
+        <ThemedText type="subtitle" style={styles.episodesHeader}>
+          Episodios
+        </ThemedText>
+        {show.episodes.map((ep, index) => (
+          <ThemedText key={ep.id}>
+            {index + 1}. {ep.title}
+          </ThemedText>
+        ))}
+      </ThemedView>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  poster: {
+    width: '100%',
+    height: 400,
+  },
+  content: {
+    padding: 16,
+    gap: 8,
+  },
+  synopsis: {
+    marginBottom: 16,
+  },
+  episodesHeader: {
+    marginTop: 16,
+    marginBottom: 8,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+});

--- a/mini-netflix/data/catalog.ts
+++ b/mini-netflix/data/catalog.ts
@@ -1,0 +1,82 @@
+export interface Episode {
+  id: string;
+  title: string;
+}
+
+export interface Show {
+  id: string;
+  title: string;
+  poster: string;
+  synopsis: string;
+  episodes: Episode[];
+}
+
+export interface Category {
+  id: string;
+  title: string;
+  shows: Show[];
+}
+
+export const catalog: Category[] = [
+  {
+    id: 'drama',
+    title: 'Drama',
+    shows: [
+      {
+        id: 'dramatic-times',
+        title: 'Dramatic Times',
+        poster: 'https://placehold.co/200x300?text=Drama+1',
+        synopsis: 'A moving tale of love and loss.',
+        episodes: [
+          { id: '1', title: 'Pilot' },
+          { id: '2', title: 'The Aftermath' },
+        ],
+      },
+      {
+        id: 'tear-jerker',
+        title: 'Tear Jerker',
+        poster: 'https://placehold.co/200x300?text=Drama+2',
+        synopsis: 'Bring the tissues for this emotional ride.',
+        episodes: [
+          { id: '1', title: 'Sad Beginnings' },
+          { id: '2', title: 'Even Sadder Middles' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'comedy',
+    title: 'Comedia',
+    shows: [
+      {
+        id: 'laugh-lounge',
+        title: 'Laugh Lounge',
+        poster: 'https://placehold.co/200x300?text=Comedy+1',
+        synopsis: 'Sketches and stand-up to brighten your day.',
+        episodes: [
+          { id: '1', title: 'Opening Night' },
+          { id: '2', title: 'Encore' },
+        ],
+      },
+      {
+        id: 'funny-bones',
+        title: 'Funny Bones',
+        poster: 'https://placehold.co/200x300?text=Comedy+2',
+        synopsis: 'A sitcom about a family of clowns.',
+        episodes: [
+          { id: '1', title: 'Big Shoes to Fill' },
+          { id: '2', title: 'Juggling Life' },
+        ],
+      },
+    ],
+  },
+];
+
+export function findShowById(id: string): Show | undefined {
+  for (const category of catalog) {
+    const show = category.shows.find((s) => s.id === id);
+    if (show) return show;
+  }
+  return undefined;
+}
+


### PR DESCRIPTION
## Summary
- build Home catalog screen with horizontal carousels per category
- add Show detail screen with synopsis and episode list
- wire stack navigation for show details

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8b8643f888320b324c9f88a5138f7